### PR TITLE
Updated docs for nodesize parameter to accurately reflect its implementation

### DIFF
--- a/man/randomForest.Rd
+++ b/man/randomForest.Rd
@@ -65,8 +65,9 @@
     sampsize is a vector of the length the number of strata, then
     sampling is stratified by strata, and the elements of sampsize
     indicate the numbers to be drawn from the strata.}
-  \item{nodesize}{Minimum size of terminal nodes.  Setting this number
-    larger causes smaller trees to be grown (and thus take less time).
+  \item{nodesize}{Minimum size for splitting a node. If subsequent child node
+    is less than \code{nodesize} the child is a terminal node.  Setting this
+    number larger causes smaller trees to be grown (and thus take less time).
     Note that the default values are different for classification (1)
     and regression (5).}
   \item{maxnodes}{Maximum number of terminal nodes trees in the forest


### PR DESCRIPTION
The documentation for randomForest currently states that nodeSize controls the size of the terminal nodes such that the number of observations in a terminal node is not less than the nodeSize. This is not accurate. The fortran code first creates a split and then checks if the resulting children have fewer observations than nodeSize. If so, the resulting child nodes are terminal and the branches are finished. This could (and often does) result in terminal nodes with fewer observations than nodeSize.
